### PR TITLE
chore: README cleanup (remove stats/stargazers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,4 +683,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🌟 Stargazers
 
-[![Stargazers repo roster for @muhittincamdali/GlobalLingo](https://starchart.cc/muhittincamdali/GlobalLingo.svg)](https://github.com/muhittincamdali/GlobalLingo/stargazers)


### PR DESCRIPTION
Removes analytics/stargazers sections to keep README focused.