### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,27 @@
+# Documentation Index
+
+- [](&)Documentation/AccessibilityAPI.md
+- [](&)Documentation/AccessibilityGuide.md
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/Architecture.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/CulturalAdaptationAPI.md
+- [](&)Documentation/CulturalAdaptationGuide.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/GlobalLingoManagerAPI.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/LocalizationAPI.md
+- [](&)Documentation/LocalizationBestPracticesGuide.md
+- [](&)Documentation/LocalizationGuide.md
+- [](&)Documentation/Performance.md
+- [](&)Documentation/PerformanceAPI.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/RTLSupportAPI.md
+- [](&)Documentation/RTLSupportGuide.md
+- [](&)Documentation/Security.md
+- [](&)Documentation/TranslationAPI.md
+- [](&)Documentation/TranslationGuide.md
+- [](&)Documentation/Troubleshooting.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,7 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/LocalizationExamples/LocalizationExample.swift
+- ``Examples/TranslationExamples/TranslationExample.swift
+- ``Examples/VoiceRecognitionExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.